### PR TITLE
Escaped single quote in string fix

### DIFF
--- a/syntaxes/vscode-scl.tmLanguage.json
+++ b/syntaxes/vscode-scl.tmLanguage.json
@@ -308,6 +308,7 @@
 		"strings": {
 			"name": "string.quoted.single.scl",
 			"begin": "'",
+			"while": "$'",
 			"end": "'",
 			"patterns": [
 				{

--- a/syntaxes/vscode-scl.tmLanguage.json
+++ b/syntaxes/vscode-scl.tmLanguage.json
@@ -276,6 +276,14 @@
 					},
 					"match": "(//).*$\\n?",
 					"name": "comment.line.double-slash.scl"
+				},
+				{
+					"captures": {
+						"2": { "name": "punctuation.definition.comment.scl"}
+					},
+					"begin": "\\(\/\\*",
+					"end": "\\*\/\\)",
+					"name": "comment.multilangblock.scl"
 				}
 			]
 		},


### PR DESCRIPTION
Escaped single quotes stopped the highlighting of strings, so added a fix for this.