### PR TITLE
Escaped single quote in string fix

### DIFF
--- a/syntaxes/vscode-scl.tmLanguage.json
+++ b/syntaxes/vscode-scl.tmLanguage.json
@@ -308,6 +308,7 @@
 		"strings": {
 			"name": "string.quoted.single.scl",
 			"begin": "'",
+			"while": "$'",
 			"end": "'",
 			"patterns": [
 				{


### PR DESCRIPTION
An escaped single quote in a string stopped the highlighting and show everything until the next single quote as a string